### PR TITLE
Add the ability for parameters to contain encoded ampersand symbols

### DIFF
--- a/qson.go
+++ b/qson.go
@@ -50,15 +50,20 @@ func Unmarshal(dst interface{}, query string) error {
 // possible. Eg the example above would output:
 //   {"bar":{"one":{"two":2,"red":112}}}
 func ToJSON(query string) ([]byte, error) {
-	escapedQuery, err := url.QueryUnescape(query)
-	if err != nil {
-		return nil, err
+	var (
+		builder    interface{} = make(map[string]interface{})
+		queryParts []string
+	)
+	params := strings.Split(query, "&")
+	for _, part := range params {
+		qStr, err := url.QueryUnescape(part)
+		if err != nil {
+			return nil, err
+		}
+		queryParts = append(queryParts, qStr)
 	}
-
-	var builder interface{} = make(map[string]interface{})
-	params := strings.Split(escapedQuery, "&")
-	for _, str := range params {
-		tempMap, err := queryToMap(str)
+	for _, part := range queryParts {
+		tempMap, err := queryToMap(part)
 		if err != nil {
 			return nil, err
 		}

--- a/qson_test.go
+++ b/qson_test.go
@@ -25,7 +25,8 @@ type unmarshalT struct {
 	B unmarshalB `json:"b"`
 }
 type unmarshalB struct {
-	C int `json:"c"`
+	C int    `json:"c"`
+	D string `json:"D"`
 }
 
 func TestUnmarshal(t *testing.T) {
@@ -132,5 +133,23 @@ func TestSplitKeyAndValue(t *testing.T) {
 	}
 	if eValue != aValue {
 		t.Errorf("Values do not match. Expected: %s Actual: %s", eValue, aValue)
+	}
+}
+
+func TestEncodedAmpersand(t *testing.T) {
+	query := "a=xyz&b[d]=ben%26jerry"
+	expected := unmarshalT{
+		A: "xyz",
+		B: unmarshalB{
+			D: "ben&jerry",
+		},
+	}
+	var actual unmarshalT
+	err := Unmarshal(&actual, query)
+	if err != nil {
+		t.Error(err)
+	}
+	if expected != actual {
+		t.Errorf("Expected: %+v Actual: %+v", expected, actual)
 	}
 }


### PR DESCRIPTION
A fix for #2 

My approach was to split before using QueryEscape so that the inner encoded ampersands (&) were did not result in invalid query parameter fragments (eg. not a real key, and do not contain an `=`).